### PR TITLE
Keep GitHub Actions up to date with GitHub's Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Keep GitHub Actions up to date with GitHub's Dependabot...
+# https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/keeping-your-actions-up-to-date-with-dependabot
+# https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#package-ecosystem
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    groups:
+      github-actions:
+        patterns:
+          - "*"  # Group all Actions updates into a single larger pull request
+    schedule:
+      interval: weekly
+    cooldown:  # https://nesbitt.io/2026/03/04/package-managers-need-to-cool-down.html
+      default-days: 7


### PR DESCRIPTION
* [Keeping your software supply chain secure with Dependabot](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain)
* [Keeping your actions up to date with Dependabot](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/keeping-your-actions-up-to-date-with-dependabot)
* [Configuration options for the `dependabot.yml` file - package-ecosystem](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#package-ecosystem-)

To see all GitHub Actions dependencies, type:
% `git grep 'uses: ' .github/workflows/`
```
.github/workflows/pre-commit.yml:      - uses: actions/checkout@v4
.github/workflows/pre-commit.yml:      - uses: actions/setup-python@v5
.github/workflows/pre-commit.yml:      - uses: pre-commit/action@v3.0.1
.github/workflows/publish-pypi.yml:      - uses: actions/checkout@v4
.github/workflows/publish-pypi.yml:      - uses: actions/setup-python@v5
.github/workflows/publish-pypi.yml:        uses: pypa/gh-action-pypi-publish@release/v1
.github/workflows/release-please.yml:      - uses: googleapis/release-please-action@v4
```