### PR TITLE
feat: Add Pi as a selectable coding agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ directly; that is often nicer for systemd or secret managers.
 ### Coding agent
 
 The optional top-level `agent` key selects the coding-agent CLI for the
-daemon. It accepts `opencode` (the default) or `omp`:
+daemon. It accepts `opencode` (the default), `omp`, or `pi`:
 
 ```yaml
 agent: omp
@@ -310,7 +310,7 @@ documented there side by side.
 ```yaml
 # config.yaml (placed in the workspace directory)
 
-# Coding-agent CLI to run (default: opencode). Must be `opencode` or `omp`.
+# Coding-agent CLI to run (default: opencode). One of `opencode`, `omp`, or `pi`.
 agent: opencode
 
 # Choose exactly one backend — linear or github.
@@ -680,6 +680,16 @@ session resumes work both from inside the daemon and from your shell. OMP
 sessions live under `~/.omp/agent/sessions/<slugified-cwd>/`; use OMP's resume
 command from the same workspace path. `~/.omp` is likewise bind-mounted into
 the sandbox for OMP's session, authentication, and run state.
+
+For a Pi session:
+
+```bash
+cd <workspace>/TEAM-42/repo
+pi --session 01b035ff-248a-735c-8173-f5ee428fe918
+```
+
+Pi sessions live under `~/.pi/agent/sessions/`; `~/.pi` is likewise
+bind-mounted into the sandbox for Pi's session and authentication state.
 
 ### Check daemon state
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -78,12 +78,12 @@ linear:
 # ---------------------------------------------------------------------------
 
 # Which coding-agent CLI the daemon launches (default: opencode).
-# One of `opencode` or `omp`.  Global for the whole daemon — there is no
-# per-project or per-issue override.  The binary must be on the sandbox
+# One of `opencode`, `omp`, or `pi`.  Global for the whole daemon — there is
+# no per-project or per-issue override.  The binary must be on the sandbox
 # PATH (see SYMPHONY_SANDBOX_PATH); the daemon refuses to start otherwise.
-# The two agents do not share sessions: changing this value makes a ticket
-# holding a session from the other agent start a fresh session on its next
-# turn, losing that ticket's conversation history.
+# Agents do not share sessions: changing this value makes a ticket holding a
+# session from the other agent start a fresh session on its next turn, losing
+# that ticket's conversation history.
 agent: opencode
 
 # Optional. Per-issue model overrides for the primary agent.  A

--- a/symphony_linear/config.py
+++ b/symphony_linear/config.py
@@ -218,9 +218,9 @@ class AppConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    agent: Literal["opencode", "omp"] = Field(
+    agent: Literal["opencode", "omp", "pi"] = Field(
         "opencode",
-        description="Coding-agent CLI to run: 'opencode' (default) or 'omp'",
+        description="Coding-agent CLI to run: 'opencode' (default), 'omp', or 'pi'",
     )
     linear: _LinearConfig | None = Field(
         None, description="Linear backend configuration block"

--- a/symphony_linear/orchestrator.py
+++ b/symphony_linear/orchestrator.py
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from symphony_linear import omp, opencode
+from symphony_linear import omp, opencode, pi
 from symphony_linear.agent_runner import AgentCancelled, AgentError, AgentTimeout
 from symphony_linear.attachments import process_attachments
 from symphony_linear.config import AppConfig
@@ -120,7 +120,11 @@ def _agent_callables(agent: str) -> tuple[Any, Any]:
     """Return the initial and resume callables for a configured agent."""
     if agent == "opencode":
         return run_initial, run_resume
-    return omp.run_initial, omp.run_resume
+    if agent == "omp":
+        return omp.run_initial, omp.run_resume
+    if agent == "pi":
+        return pi.run_initial, pi.run_resume
+    raise ValueError(f"Unknown agent: {agent!r}")
 
 
 # ---------------------------------------------------------------------------

--- a/symphony_linear/pi.py
+++ b/symphony_linear/pi.py
@@ -1,0 +1,371 @@
+"""Pi adapter for symphony-lite.
+
+Launches Pi inside the bwrap sandbox and extracts the session ID, final
+assistant reply, and context-window token count from Pi's NDJSON stream.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+from pathlib import Path
+from typing import Callable
+
+from symphony_linear import agent_runner
+
+logger = logging.getLogger(__name__)
+
+# Keep adapter-facing exception names while sharing the agent-neutral classes
+# used by the orchestrator-facing runner.
+PiError = agent_runner.AgentError
+PiTimeout = agent_runner.AgentTimeout
+PiCancelled = agent_runner.AgentCancelled
+
+
+def run_initial(
+    workspace_path: str,
+    prompt: str,
+    *,
+    timeout_seconds: int,
+    idle_timeout_seconds: int,
+    on_subprocess: Callable[[subprocess.Popen[bytes]], None],
+    hide_paths: list[str] | None = None,
+    extra_rw_paths: list[str] | None = None,
+    attachments_path: str | None = None,
+    dir_map: list[tuple[str, str]] | None = None,
+    tmp_path: str,
+    files: list[str] | None = None,
+    model: str | None = None,
+) -> tuple[str, str, int | None]:
+    """Launch Pi for a new session.
+
+    Returns ``(session_id, final_message, context_tokens)``.  ``files`` are
+    passed as Pi positional attachment arguments and ``model`` optionally
+    overrides the primary agent's model.
+
+    Pi has no ``--cwd`` flag; the working directory is set by bwrap's
+    ``--chdir`` instead.  Pi has no ``--auto-approve`` flag; its ``-a`` /
+    ``--approve`` flag means "trust project-local files" — a different and
+    riskier semantic that is deliberately not passed here, so untrusted ticket
+    repositories cannot inject local extensions or skills.
+    """
+    cmd: list[str] = ["pi", "-p", "--mode", "json"]
+    if model:
+        cmd += ["--model", model]
+    if files:
+        cmd += [f"@{file}" for file in files]
+
+    # Pi treats a positional message starting with '@' as a file attachment.
+    # Prefix every prompt, even one that already starts with a newline.
+    cmd.append("\n" + prompt)
+
+    return _execute(
+        cmd=cmd,
+        workspace_path=workspace_path,
+        timeout_seconds=timeout_seconds,
+        idle_timeout_seconds=idle_timeout_seconds,
+        on_subprocess=on_subprocess,
+        hide_paths=hide_paths or [],
+        extra_rw_paths=_agent_dir_rw_paths(extra_rw_paths),
+        attachments_path=attachments_path,
+        dir_map=dir_map,
+        tmp_path=tmp_path,
+    )
+
+
+def run_resume(
+    workspace_path: str,
+    session_id: str | None,
+    message: str,
+    *,
+    timeout_seconds: int,
+    idle_timeout_seconds: int,
+    on_subprocess: Callable[[subprocess.Popen[bytes]], None],
+    hide_paths: list[str] | None = None,
+    extra_rw_paths: list[str] | None = None,
+    attachments_path: str | None = None,
+    dir_map: list[tuple[str, str]] | None = None,
+    tmp_path: str,
+    files: list[str] | None = None,
+    model: str | None = None,
+) -> tuple[str, int | None]:
+    """Resume a Pi session with a follow-up message.
+
+    Returns ``(final_message, context_tokens)``.  An empty session ID is
+    rejected so Pi cannot silently start an unrelated new session.
+
+    IMPORTANT: Pi's ``-r`` / ``--resume`` flag is an INTERACTIVE SESSION
+    PICKER that takes NO argument (unlike OMP's ``-r <id>``).  Never use
+    ``-r`` here; ``--session <id>`` is the correct non-interactive resume
+    flag.  If ``-r`` were used, the session id would be consumed as a
+    positional message and Pi would silently start a fresh session.
+    """
+    if not session_id:
+        raise PiError(
+            "run_resume requires a non-empty session_id; refusing to launch "
+            "an empty Pi session"
+        )
+
+    # --session <id> is the non-interactive resume flag.  Do NOT use -r here:
+    # Pi's -r/--resume is an interactive session picker with no argument — the
+    # session id would be treated as a positional message, silently starting a
+    # fresh session instead of resuming the intended one.
+    cmd: list[str] = ["pi", "-p", "--mode", "json", "--session", session_id]
+    if model:
+        cmd += ["--model", model]
+    if files:
+        cmd += [f"@{file}" for file in files]
+
+    # See the corresponding initial-turn comment above.
+    cmd.append("\n" + message)
+
+    _, final_message, context_tokens = _execute(
+        cmd=cmd,
+        workspace_path=workspace_path,
+        timeout_seconds=timeout_seconds,
+        idle_timeout_seconds=idle_timeout_seconds,
+        on_subprocess=on_subprocess,
+        hide_paths=hide_paths or [],
+        extra_rw_paths=_agent_dir_rw_paths(extra_rw_paths),
+        attachments_path=attachments_path,
+        dir_map=dir_map,
+        tmp_path=tmp_path,
+    )
+    return final_message, context_tokens
+
+
+def _agent_dir_rw_paths(extra_rw_paths: list[str] | None) -> list[str]:
+    """Return extra_rw_paths extended with the Pi agent dir when configured.
+
+    The default ``~/.pi`` location is handled in sandbox.py via
+    ``--bind-try``; only the non-default ``PI_CODING_AGENT_DIR`` path needs
+    explicit ``--bind`` treatment here.  ``--bind`` is fatal for missing
+    paths, so we only add it when the directory actually exists.
+    """
+    base = list(extra_rw_paths or [])
+
+    agent_dir_env = os.environ.get("PI_CODING_AGENT_DIR")
+    if not agent_dir_env:
+        return base
+
+    agent_dir = Path(agent_dir_env).expanduser()
+    if not os.path.isdir(agent_dir):
+        logger.warning(
+            "PI_CODING_AGENT_DIR is set to %s but that directory does not exist "
+            "on the host. The sandbox read-write bind will be skipped (--bind is "
+            "fatal on missing paths). Pi will resolve the path under the "
+            "read-only root bind and crash with EROFS at the first session "
+            "flush. Create the directory on the host before starting the daemon.",
+            agent_dir,
+        )
+        return base
+
+    resolved = os.path.realpath(agent_dir)
+    # Dedupe: skip if the resolved path is already in the list.
+    existing_realpaths = {os.path.realpath(p) for p in base}
+    if resolved not in existing_realpaths:
+        base.append(str(agent_dir))
+
+    return base
+
+
+def _build_env() -> dict[str, str]:
+    """Build the environment dict for the sandboxed Pi process."""
+    env: dict[str, str] = {"HOME": str(Path.home())}
+    pi_agent_dir = os.environ.get("PI_CODING_AGENT_DIR")
+    if pi_agent_dir:
+        env["PI_CODING_AGENT_DIR"] = pi_agent_dir
+    return env
+
+
+def _execute(
+    cmd: list[str],
+    workspace_path: str,
+    tmp_path: str,
+    timeout_seconds: int,
+    idle_timeout_seconds: int,
+    on_subprocess: Callable[[subprocess.Popen[bytes]], None],
+    hide_paths: list[str] | None = None,
+    extra_rw_paths: list[str] | None = None,
+    attachments_path: str | None = None,
+    dir_map: list[tuple[str, str]] | None = None,
+) -> tuple[str, str, int | None]:
+    """Run a Pi command, then parse and validate its NDJSON event stream."""
+    returncode, stdout_text, stderr_text, timeout_reason = agent_runner.run(
+        cmd=cmd,
+        workspace_path=workspace_path,
+        tmp_path=tmp_path,
+        timeout_seconds=timeout_seconds,
+        idle_timeout_seconds=idle_timeout_seconds,
+        on_subprocess=on_subprocess,
+        env=_build_env(),
+        hide_paths=hide_paths,
+        extra_rw_paths=extra_rw_paths or [],
+        attachments_path=attachments_path,
+        dir_map=dir_map,
+    )
+
+    if timeout_reason is not None:
+        stderr_tail = agent_runner._tail(stderr_text)
+        try:
+            partial_session_id, partial_events = _parse_stream(stdout_text)
+            partial_message = _assemble_message(partial_events)
+        except Exception:
+            logger.debug("Failed to salvage partial output on timeout", exc_info=True)
+            partial_session_id = None
+            partial_message = ""
+        raise PiTimeout(
+            f"Pi turn timed out: {timeout_reason}\nstderr: {stderr_tail}",
+            partial_message=partial_message,
+            session_id=partial_session_id,
+            reason=timeout_reason,
+        )
+
+    logger.debug("=== raw Pi stdout ===\n%s\n=== end stdout ===", stdout_text)
+    if stderr_text:
+        logger.debug("=== raw Pi stderr ===\n%s\n=== end stderr ===", stderr_text)
+
+    session_id, parsed_events = _parse_stream(stdout_text)
+    context_tokens = _extract_context_tokens(parsed_events)
+
+    # Preserve the runner's cancellation distinction before handling a generic
+    # non-zero exit, then validate protocol essentials before assembling text.
+    if returncode is not None and returncode < 0:
+        raise PiCancelled(f"Pi process killed by signal {-returncode}")
+
+    if returncode != 0:
+        raise PiError(
+            f"Pi exited with code {returncode}\nstderr: {stderr_text[-2000:]}"
+        )
+
+    if session_id is None:
+        raise PiError(
+            "No session ID found in Pi JSON stream.\n"
+            f"stdout: {stdout_text[:2000]}\n"
+            f"stderr: {stderr_text[-2000:]}"
+        )
+
+    return session_id, _assemble_final_reply(parsed_events), context_tokens
+
+
+def _parse_stream(stdout_text: str) -> tuple[str | None, list[dict]]:
+    """Parse a lenient Pi NDJSON stream into its session ID and event list.
+
+    Corrupt lines and JSON values other than objects are logged at DEBUG and
+    skipped.  This also tolerates a truncated final line after a timeout.
+    """
+    session_id: str | None = None
+    parsed_events: list[dict] = []
+
+    for line in stdout_text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        try:
+            event = json.loads(stripped)
+        except json.JSONDecodeError:
+            logger.debug("Skipping unparseable JSON line: %s", stripped[:200])
+            continue
+
+        if not isinstance(event, dict):
+            logger.debug("Skipping non-dict JSON value: %s", stripped[:200])
+            continue
+
+        if session_id is None and event.get("type") == "session":
+            candidate = event.get("id")
+            if isinstance(candidate, str) and candidate:
+                session_id = candidate
+
+        parsed_events.append(event)
+
+    return session_id, parsed_events
+
+
+def _assemble_final_reply(events: list[dict]) -> str:
+    """Return text parts from the final ``turn_end`` event's message.
+
+    Pi keeps subagent activity inside tool-execution results, so the final
+    turn-end message is already the complete top-level assistant reply.
+    """
+    for event in reversed(events):
+        if event.get("type") != "turn_end":
+            continue
+
+        message = event.get("message")
+        if not isinstance(message, dict):
+            return ""
+        content = message.get("content")
+        if not isinstance(content, list):
+            return ""
+
+        segments: list[str] = []
+        for part in content:
+            if not isinstance(part, dict) or part.get("type") != "text":
+                continue
+            text = part.get("text")
+            if isinstance(text, str):
+                segments.append(text)
+        return "\n\n".join(segments).strip()
+
+    return ""
+
+
+def _assemble_message(events: list[dict]) -> str:
+    """Assemble a full Pi trace for a timeout diagnostic.
+
+    ``message_update`` text-end events contain each streamed text part in full.
+    Tool-execution starts supply concise activity labels while a turn is still
+    running.  This function is intentionally only used for timeout salvage.
+    """
+    segments: list[str] = []
+    for event in events:
+        event_type = event.get("type")
+        if event_type == "message_update":
+            assistant_event = event.get("assistantMessageEvent")
+            if not isinstance(assistant_event, dict):
+                continue
+            if assistant_event.get("type") != "text_end":
+                continue
+            content = assistant_event.get("content")
+            if isinstance(content, str) and content:
+                segments.append(content)
+
+        elif event_type == "tool_execution_start":
+            intent = event.get("intent")
+            tool_name = event.get("toolName")
+            label = intent if isinstance(intent, str) and intent else tool_name
+            if isinstance(label, str) and label:
+                segments.append(f"*{label}*")
+
+    return "\n\n".join(segments).strip()
+
+
+def _extract_context_tokens(events: list[dict]) -> int | None:
+    """Return input plus cache reads/writes from the final ``turn_end``.
+
+    Missing or malformed token fields default to zero.  ``None`` means Pi
+    never emitted a turn-end event at all.
+    """
+    for event in reversed(events):
+        if event.get("type") != "turn_end":
+            continue
+
+        message = event.get("message")
+        usage = message.get("usage") if isinstance(message, dict) else None
+        if not isinstance(usage, dict):
+            return 0
+        return (
+            _token_count(usage.get("input"))
+            + _token_count(usage.get("cacheRead"))
+            + _token_count(usage.get("cacheWrite"))
+        )
+
+    return None
+
+
+def _token_count(value: object) -> int:
+    """Treat missing or malformed Pi usage values as zero."""
+    return value if isinstance(value, int) else 0

--- a/symphony_linear/sandbox.py
+++ b/symphony_linear/sandbox.py
@@ -151,9 +151,11 @@ def run_in_sandbox(
     opencode_legacy = str(Path("~/.opencode").expanduser())
     opencode_xdg = str(Path("~/.local/share/opencode").expanduser())
     omp_dir = str(Path("~/.omp").expanduser())
+    pi_dir = str(Path("~/.pi").expanduser())
     bwrap_args.extend(["--bind-try", opencode_legacy, opencode_legacy])
     bwrap_args.extend(["--bind-try", opencode_xdg, opencode_xdg])
     bwrap_args.extend(["--bind-try", omp_dir, omp_dir])
+    bwrap_args.extend(["--bind-try", pi_dir, pi_dir])
 
     # 5. Extra read-write paths (applied before hide_paths so hide wins on
     #    collision — later bwrap mounts override earlier ones).

--- a/tests/fixtures/pi_events.jsonl
+++ b/tests/fixtures/pi_events.jsonl
@@ -1,0 +1,13 @@
+{"type":"session","version":3,"id":"01b035ff-248a-735c-8173-f5ee428fe918","timestamp":"2026-08-24T23:10:05.123Z","cwd":"/tmp/pi/pi-probe"}
+{"type":"agent_start"}
+{"type":"turn_start"}
+{"type":"message_start","message":{"role":"user","content":[{"type":"text","text":"Say exactly: hello"}],"attribution":"user","timestamp":1787612400000}}
+{"type":"message_end","message":{"role":"user","content":[{"type":"text","text":"Say exactly: hello"}],"attribution":"user","timestamp":1787612400000}}
+{"type":"message_start","message":{"role":"assistant","content":[{"type":"text","text":"h"}],"api":"anthropic-messages","provider":"anthropic","model":"claude-opus-5","usage":{"input":5,"output":1,"cacheRead":10,"cacheWrite":3000,"totalTokens":3016},"stopReason":"stop","timestamp":1787612400100,"responseId":"msg_pitest01"}}
+{"type":"message_update","assistantMessageEvent":{"type":"text_start","contentIndex":0}}
+{"type":"message_update","assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":"h"}}
+{"type":"message_update","assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":"ello"}}
+{"type":"message_update","assistantMessageEvent":{"type":"text_end","contentIndex":0,"content":"hello"}}
+{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"hello"}],"api":"anthropic-messages","provider":"anthropic","model":"claude-opus-5","usage":{"input":5,"output":4,"cacheRead":10,"cacheWrite":3000,"totalTokens":3019},"stopReason":"stop","timestamp":1787612400100,"responseId":"msg_pitest01","duration":1200.0,"ttft":800.0}}
+{"type":"turn_end","message":{"role":"assistant","content":[{"type":"text","text":"hello"}],"api":"anthropic-messages","provider":"anthropic","model":"claude-opus-5","usage":{"input":5,"output":4,"cacheRead":10,"cacheWrite":3000,"totalTokens":3019},"stopReason":"stop","timestamp":1787612400100,"responseId":"msg_pitest01","duration":1200.0,"ttft":800.0},"toolResults":[]}
+{"type":"agent_end","messages":[{"role":"user","content":[{"type":"text","text":"Say exactly: hello"}],"attribution":"user","timestamp":1787612400000},{"role":"assistant","content":[{"type":"text","text":"hello"}],"api":"anthropic-messages","provider":"anthropic","model":"claude-opus-5","usage":{"input":5,"output":4,"cacheRead":10,"cacheWrite":3000,"totalTokens":3019},"stopReason":"stop","timestamp":1787612400100,"responseId":"msg_pitest01","duration":1200.0,"ttft":800.0}],"isTerminal":true}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -283,3 +283,65 @@ linear:
         assert "PATH" in stderr
         assert str(sandbox_bin) in stderr
         assert "SYMPHONY_SANDBOX_PATH" in stderr
+
+
+# ---------------------------------------------------------------------------
+# Pi agent binary check
+# ---------------------------------------------------------------------------
+
+
+class TestPiAgentBinaryCheck:
+    def test_pi_agent_present_on_sandbox_path_passes(self, tmp_path: Path) -> None:
+        """agent: pi with `pi` present on sandbox PATH passes startup."""
+        _write_config(
+            tmp_path,
+            """\
+agent: pi
+linear:
+  api_key: test-key
+""",
+        )
+        with (
+            mock.patch("symphony_linear.cli.load_state") as mock_load_state,
+            mock.patch("symphony_linear.cli._create_tracker") as mock_create_tracker,
+            mock.patch("symphony_linear.cli.Orchestrator") as mock_orch_class,
+            mock.patch(
+                "symphony_linear.cli.shutil.which", return_value="/usr/bin/pi"
+            ) as mock_which,
+        ):
+            mock_load_state.return_value = mock.MagicMock()
+            mock_create_tracker.return_value = mock.MagicMock()
+            mock_orch_class.return_value = mock.MagicMock()
+
+            main(["--workspace", str(tmp_path)])
+
+        mock_which.assert_called_once_with("pi", path=mock.ANY)
+
+    def test_pi_agent_absent_exits_1_naming_pi(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """agent: pi with `pi` absent on sandbox PATH exits 1 naming 'pi'."""
+        _write_config(
+            tmp_path,
+            """\
+agent: pi
+linear:
+  api_key: test-key
+""",
+        )
+        sandbox_bin = tmp_path / "sandbox-bin"
+        sandbox_bin.mkdir()
+        monkeypatch.setenv("PATH", str(tmp_path / "daemon-bin"))
+        monkeypatch.setenv("SYMPHONY_SANDBOX_PATH", str(sandbox_bin))
+        monkeypatch.setattr("symphony_linear.cli.shutil.which", shutil_which)
+
+        with pytest.raises(SystemExit) as excinfo:
+            main(["--workspace", str(tmp_path), "--validate-config"])
+
+        assert excinfo.value.code == 1
+        stderr = capsys.readouterr().err
+        assert "pi" in stderr
+        assert "SYMPHONY_SANDBOX_PATH" in stderr

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -115,6 +115,18 @@ class TestLoadConfig:
         config = load_config(tmp_path)
         assert config.agent == "omp"
 
+    def test_agent_can_be_pi(self, tmp_path: Path) -> None:
+        cfg = {
+            "agent": "pi",
+            "linear": {
+                "api_key": "test-key",
+            },
+        }
+        _write_yaml(tmp_path / "config.yaml", cfg)
+
+        config = load_config(tmp_path)
+        assert config.agent == "pi"
+
     def test_invalid_agent_is_rejected(self, tmp_path: Path) -> None:
         cfg = {
             "agent": "other",

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -318,6 +318,38 @@ class TestNewTicketPipeline:
         assert ticket_state is not None
         assert ticket_state.agent == "omp"
 
+    def test_pi_dispatches_initial_and_tags_session(
+        self, orchestrator: Orchestrator, linear: FakeLinearClient
+    ) -> None:
+        orchestrator._config.agent = "pi"
+        with (
+            mock.patch("symphony_linear.orchestrator.clone_workspace") as mock_clone,
+            mock.patch(
+                "symphony_linear.orchestrator.finalize_workspace"
+            ) as mock_finalize,
+            mock.patch(
+                "symphony_linear.orchestrator.load_project_config"
+            ) as mock_load_config,
+            mock.patch("symphony_linear.orchestrator.run_initial") as mock_opencode,
+            mock.patch("symphony_linear.orchestrator.omp.run_initial") as mock_omp,
+            mock.patch("symphony_linear.orchestrator.pi.run_initial") as mock_pi,
+        ):
+            issue = self._setup_mocks(
+                mock_clone,
+                mock_finalize,
+                mock_load_config,
+                mock_pi,
+                linear,
+            )
+            orchestrator._new_ticket_pipeline(issue)
+
+        mock_opencode.assert_not_called()
+        mock_omp.assert_not_called()
+        mock_pi.assert_called_once()
+        ticket_state = orchestrator._state.get("ticket-1")
+        assert ticket_state is not None
+        assert ticket_state.agent == "pi"
+
     def test_turn_input_marker_set_to_baseline(
         self, orchestrator: Orchestrator, linear: FakeLinearClient
     ) -> None:
@@ -2063,6 +2095,196 @@ class TestResumePipeline:
 
         mock_opencode.assert_not_called()
         mock_omp.assert_called_once()
+
+    def test_pi_dispatches_resume(
+        self, orchestrator: Orchestrator, linear: FakeLinearClient
+    ) -> None:
+        orchestrator._config.agent = "pi"
+        ts = self._make_ts(agent="pi")
+        orchestrator._state.upsert(ts)
+        linear.set_response("list_comments_since", [_make_comment("c1", "Fix please")])
+        with (
+            mock.patch(
+                "symphony_linear.orchestrator.load_project_config",
+                return_value=ProjectConfig(),
+            ),
+            mock.patch("symphony_linear.orchestrator.run_resume") as mock_opencode,
+            mock.patch("symphony_linear.orchestrator.omp.run_resume") as mock_omp,
+            mock.patch(
+                "symphony_linear.orchestrator.pi.run_resume",
+                return_value=("Done!", None),
+            ) as mock_pi,
+        ):
+            orchestrator._resume_pipeline(ts)
+
+        mock_opencode.assert_not_called()
+        mock_omp.assert_not_called()
+        mock_pi.assert_called_once()
+
+    def test_pi_agent_mismatch_starts_initial_pipeline(
+        self, orchestrator: Orchestrator, linear: FakeLinearClient
+    ) -> None:
+        """A stored opencode session is discarded when config agent is pi."""
+        from symphony_linear.state import SessionRecord
+
+        orchestrator._config.agent = "pi"
+        ts = self._make_ts(agent="opencode")
+        orchestrator._state.upsert(ts)
+        orchestrator._state.set_session(
+            "ticket-1", SessionRecord(session_id="ses-opencode", agent="opencode")
+        )
+        linear.set_response("list_comments_since", [_make_comment("c1", "Fix please")])
+        linear.set_response("get_issue", _make_issue(description="Fix the bug"))
+        linear.set_response(
+            "get_project",
+            Project(
+                id="proj-1",
+                name="Test",
+                links=[
+                    ProjectLink(label="Repo", url="https://github.com/org/repo.git")
+                ],
+            ),
+        )
+        with (
+            mock.patch(
+                "symphony_linear.orchestrator.clone_workspace",
+                return_value=("/tmp/ws/TEAM-1", False),
+            ),
+            mock.patch("symphony_linear.orchestrator.finalize_workspace"),
+            mock.patch(
+                "symphony_linear.orchestrator.load_project_config",
+                return_value=ProjectConfig(),
+            ),
+            mock.patch("symphony_linear.orchestrator.omp.run_initial") as mock_omp,
+            mock.patch(
+                "symphony_linear.orchestrator.run_resume"
+            ) as mock_opencode_resume,
+            mock.patch(
+                "symphony_linear.orchestrator.pi.run_initial",
+                return_value=("pi-session", "Done.", None),
+            ) as mock_pi_initial,
+            mock.patch("symphony_linear.orchestrator.pi.run_resume") as mock_pi_resume,
+        ):
+            orchestrator._resume_pipeline(ts)
+
+        mock_omp.assert_not_called()
+        mock_opencode_resume.assert_not_called()
+        mock_pi_resume.assert_not_called()
+        mock_pi_initial.assert_called_once()
+        prompt = mock_pi_initial.call_args.kwargs["prompt"]
+        assert "Fix the bug" in prompt
+        assert "Fix please" in prompt
+        ticket_state = orchestrator._state.get("ticket-1")
+        assert ticket_state is not None
+        assert ticket_state.session_id == "pi-session"
+        assert ticket_state.agent == "pi"
+        assert orchestrator._state.get_session("ticket-1") is None
+
+    def test_pi_session_discarded_under_opencode(
+        self, orchestrator: Orchestrator, linear: FakeLinearClient
+    ) -> None:
+        """A pi-tagged stored session is discarded when config agent is opencode."""
+        from symphony_linear.state import SessionRecord
+
+        # Default config agent is "opencode"
+        ts = self._make_ts(agent="pi")
+        orchestrator._state.upsert(ts)
+        orchestrator._state.set_session(
+            "ticket-1", SessionRecord(session_id="ses-pi", agent="pi")
+        )
+        linear.set_response("list_comments_since", [_make_comment("c1", "Fix please")])
+        linear.set_response("get_issue", _make_issue(description="Fix the bug"))
+        linear.set_response(
+            "get_project",
+            Project(
+                id="proj-1",
+                name="Test",
+                links=[
+                    ProjectLink(label="Repo", url="https://github.com/org/repo.git")
+                ],
+            ),
+        )
+        with (
+            mock.patch(
+                "symphony_linear.orchestrator.clone_workspace",
+                return_value=("/tmp/ws/TEAM-1", False),
+            ),
+            mock.patch("symphony_linear.orchestrator.finalize_workspace"),
+            mock.patch(
+                "symphony_linear.orchestrator.load_project_config",
+                return_value=ProjectConfig(),
+            ),
+            mock.patch(
+                "symphony_linear.orchestrator.run_initial",
+                return_value=("oc-session", "Done.", None),
+            ) as mock_opencode_initial,
+            mock.patch(
+                "symphony_linear.orchestrator.pi.run_initial"
+            ) as mock_pi_initial,
+            mock.patch("symphony_linear.orchestrator.pi.run_resume") as mock_pi_resume,
+        ):
+            orchestrator._resume_pipeline(ts)
+
+        mock_pi_initial.assert_not_called()
+        mock_pi_resume.assert_not_called()
+        mock_opencode_initial.assert_called_once()
+        ticket_state = orchestrator._state.get("ticket-1")
+        assert ticket_state is not None
+        assert ticket_state.session_id == "oc-session"
+        assert ticket_state.agent == "opencode"
+        assert orchestrator._state.get_session("ticket-1") is None
+
+    def test_none_agent_session_discarded_under_pi(
+        self, orchestrator: Orchestrator, linear: FakeLinearClient
+    ) -> None:
+        """A legacy session (agent=None, meaning opencode) is discarded under pi config."""
+        from symphony_linear.state import SessionRecord
+
+        orchestrator._config.agent = "pi"
+        ts = self._make_ts(agent=None)  # legacy / no agent tag
+        orchestrator._state.upsert(ts)
+        orchestrator._state.set_session(
+            "ticket-1", SessionRecord(session_id="ses-legacy", agent=None)
+        )
+        linear.set_response("list_comments_since", [_make_comment("c1", "Fix please")])
+        linear.set_response("get_issue", _make_issue(description="Fix the bug"))
+        linear.set_response(
+            "get_project",
+            Project(
+                id="proj-1",
+                name="Test",
+                links=[
+                    ProjectLink(label="Repo", url="https://github.com/org/repo.git")
+                ],
+            ),
+        )
+        with (
+            mock.patch(
+                "symphony_linear.orchestrator.clone_workspace",
+                return_value=("/tmp/ws/TEAM-1", False),
+            ),
+            mock.patch("symphony_linear.orchestrator.finalize_workspace"),
+            mock.patch(
+                "symphony_linear.orchestrator.load_project_config",
+                return_value=ProjectConfig(),
+            ),
+            mock.patch(
+                "symphony_linear.orchestrator.run_resume"
+            ) as mock_opencode_resume,
+            mock.patch(
+                "symphony_linear.orchestrator.pi.run_initial",
+                return_value=("pi-session", "Done.", None),
+            ) as mock_pi_initial,
+            mock.patch("symphony_linear.orchestrator.pi.run_resume") as mock_pi_resume,
+        ):
+            orchestrator._resume_pipeline(ts)
+
+        mock_opencode_resume.assert_not_called()
+        mock_pi_resume.assert_not_called()
+        mock_pi_initial.assert_called_once()
+        ticket_state = orchestrator._state.get("ticket-1")
+        assert ticket_state is not None
+        assert ticket_state.agent == "pi"
 
     def test_agent_mismatch_starts_initial_pipeline(
         self, orchestrator: Orchestrator, linear: FakeLinearClient

--- a/tests/test_pi.py
+++ b/tests/test_pi.py
@@ -1,0 +1,649 @@
+"""Tests for the Pi agent adapter.
+
+The tests use captured NDJSON and a mocked shared runner; they never invoke
+the real ``pi`` binary or an LLM.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from symphony_linear import agent_runner
+from symphony_linear.pi import (
+    PiCancelled,
+    PiError,
+    PiTimeout,
+    _assemble_final_reply,
+    _assemble_message,
+    _extract_context_tokens,
+    _parse_stream,
+    run_initial,
+    run_resume,
+)
+
+FIXTURE_PATH = Path(__file__).resolve().parent / "fixtures" / "pi_events.jsonl"
+
+
+def _fixture_text() -> str:
+    """Return the captured Pi NDJSON stream for a completed simple turn."""
+    return FIXTURE_PATH.read_text()
+
+
+# ---------------------------------------------------------------------------
+# Fixture parsing
+# ---------------------------------------------------------------------------
+
+
+class TestCapturedEvents:
+    """Validate extraction against a real Pi event stream."""
+
+    def test_extracts_session_reply_and_context_tokens(self) -> None:
+        session_id, events = _parse_stream(_fixture_text())
+
+        assert session_id == "01b035ff-248a-735c-8173-f5ee428fe918"
+        assert len(events) == 13
+        assert _assemble_final_reply(events) == "hello"
+        # input(5) + cacheRead(10) + cacheWrite(3000) = 3015
+        assert _extract_context_tokens(events) == 3015
+
+    def test_parser_skips_corrupt_non_dict_and_truncated_lines(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        stream = _fixture_text() + '\nnull\n["not", "an", "event"]\nnot json\n{"type"'
+
+        with caplog.at_level(logging.DEBUG):
+            session_id, events = _parse_stream(stream)
+
+        assert session_id == "01b035ff-248a-735c-8173-f5ee428fe918"
+        assert len(events) == 13
+        assert any("Skipping" in record.message for record in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# turn_end extraction
+# ---------------------------------------------------------------------------
+
+
+class TestFinalTurnExtraction:
+    """The success reply and context come only from the final turn_end."""
+
+    def test_last_turn_end_wins_and_keeps_only_text_parts(self) -> None:
+        events = [
+            {
+                "type": "turn_end",
+                "message": {
+                    "content": [{"type": "text", "text": "Earlier answer"}],
+                    "usage": {"input": 1, "cacheRead": 2, "cacheWrite": 3},
+                },
+            },
+            {
+                "type": "tool_execution_start",
+                "toolName": "bash",
+                "intent": "A tool after the earlier turn",
+            },
+            {
+                "type": "turn_end",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "Hidden reasoning"},
+                        {"type": "text", "text": "Final first part"},
+                        {"type": "toolCall", "name": "bash"},
+                        {"type": "text", "text": "Final second part"},
+                    ],
+                    "usage": {"input": 7, "cacheRead": 11, "cacheWrite": 13},
+                },
+            },
+        ]
+
+        assert _assemble_final_reply(events) == "Final first part\n\nFinal second part"
+        assert _extract_context_tokens(events) == 31
+
+    def test_missing_turn_end_has_no_reply_or_context(self) -> None:
+        events = [{"type": "message_update", "assistantMessageEvent": {}}]
+
+        assert _assemble_final_reply(events) == ""
+        assert _extract_context_tokens(events) is None
+
+    def test_missing_usage_fields_default_to_zero(self) -> None:
+        events = [{"type": "turn_end", "message": {"usage": {"input": 5}}}]
+
+        assert _extract_context_tokens(events) == 5
+
+
+# ---------------------------------------------------------------------------
+# Timeout trace
+# ---------------------------------------------------------------------------
+
+
+class TestTimeoutTrace:
+    """Timeout diagnostics keep streamed text and tool activity in order."""
+
+    @staticmethod
+    def _partial_events() -> list[dict]:
+        return [
+            {
+                "type": "message_update",
+                "assistantMessageEvent": {"type": "text_start", "contentIndex": 0},
+            },
+            {
+                "type": "message_update",
+                "assistantMessageEvent": {
+                    "type": "text_delta",
+                    "contentIndex": 0,
+                    "delta": "Working",
+                },
+            },
+            {
+                "type": "message_update",
+                "assistantMessageEvent": {
+                    "type": "text_end",
+                    "contentIndex": 0,
+                    "content": "Working...",
+                },
+            },
+            {
+                "type": "tool_execution_start",
+                "toolName": "bash",
+                "intent": "Listing current directory",
+            },
+            {
+                "type": "message_update",
+                "assistantMessageEvent": {
+                    "type": "text_end",
+                    "contentIndex": 0,
+                    "content": "Done.",
+                },
+            },
+            {"type": "tool_execution_start", "toolName": "read"},
+        ]
+
+    def test_assembly_uses_text_end_and_tool_execution_start(self) -> None:
+        assert _assemble_message(self._partial_events()) == (
+            "Working...\n\n*Listing current directory*\n\nDone.\n\n*read*"
+        )
+
+    def test_timeout_has_salvaged_trace_and_session(self) -> None:
+        events = [
+            {"type": "session", "id": "pi-timeout"},
+            *self._partial_events(),
+        ]
+        stdout = "\n".join(json.dumps(event) for event in events)
+
+        with patch(
+            "symphony_linear.pi.agent_runner.run",
+            return_value=(-9, stdout, "still running", "produced no output for 60s"),
+        ):
+            with pytest.raises(PiTimeout) as excinfo:
+                _run_initial()
+
+        exc = excinfo.value
+        assert exc.session_id == "pi-timeout"
+        assert exc.partial_message == (
+            "Working...\n\n*Listing current directory*\n\nDone.\n\n*read*"
+        )
+        assert exc.reason == "produced no output for 60s"
+
+
+# ---------------------------------------------------------------------------
+# Command construction
+# ---------------------------------------------------------------------------
+
+
+class TestCommandConstruction:
+    """Pi's CLI differs from OMP's flag and attachment syntax."""
+
+    def test_initial_command_no_cwd_no_auto_approve(self) -> None:
+        """Pi has no --cwd flag and no --auto-approve flag."""
+        with patch(
+            "symphony_linear.pi.agent_runner.run",
+            return_value=(0, _fixture_text(), "", None),
+        ) as runner:
+            run_initial(
+                workspace_path="/workspace",
+                tmp_path="/workspace/tmp",
+                prompt="do it",
+                timeout_seconds=60,
+                idle_timeout_seconds=30,
+                on_subprocess=lambda process: None,
+            )
+
+        cmd = runner.call_args.kwargs["cmd"]
+        assert "--cwd" not in cmd
+        assert "--auto-approve" not in cmd
+
+    def test_initial_command_structure_flags_ordering_and_attachments(self) -> None:
+        with patch(
+            "symphony_linear.pi.agent_runner.run",
+            return_value=(0, _fixture_text(), "", None),
+        ) as runner:
+            session_id, message, context_tokens = run_initial(
+                workspace_path="/workspace",
+                tmp_path="/workspace/tmp",
+                prompt="@developer implement this",
+                timeout_seconds=60,
+                idle_timeout_seconds=30,
+                on_subprocess=lambda process: None,
+                hide_paths=["/secret"],
+                extra_rw_paths=["/shared"],
+                attachments_path="/workspace/attachments",
+                dir_map=[("/host/mount", "/sandbox/mount")],
+                files=["/workspace/attachments/brief.md", "notes.txt"],
+                model="anthropic/claude-opus-5",
+            )
+
+        assert (session_id, message, context_tokens) == (
+            "01b035ff-248a-735c-8173-f5ee428fe918",
+            "hello",
+            3015,
+        )
+        assert runner.call_args.kwargs["cmd"] == [
+            "pi",
+            "-p",
+            "--mode",
+            "json",
+            "--model",
+            "anthropic/claude-opus-5",
+            "@/workspace/attachments/brief.md",
+            "@notes.txt",
+            "\n@developer implement this",
+        ]
+        kwargs = runner.call_args.kwargs
+        assert kwargs["hide_paths"] == ["/secret"]
+        assert kwargs["attachments_path"] == "/workspace/attachments"
+        assert kwargs["dir_map"] == [("/host/mount", "/sandbox/mount")]
+
+    def test_initial_omits_model_when_not_given(self) -> None:
+        with patch(
+            "symphony_linear.pi.agent_runner.run",
+            return_value=(0, _fixture_text(), "", None),
+        ) as runner:
+            run_initial(
+                workspace_path="/workspace",
+                tmp_path="/workspace/tmp",
+                prompt="do it",
+                timeout_seconds=60,
+                idle_timeout_seconds=30,
+                on_subprocess=lambda process: None,
+            )
+
+        cmd = runner.call_args.kwargs["cmd"]
+        assert "--model" not in cmd
+
+    def test_resume_uses_session_flag_not_dash_r(self) -> None:
+        """Verify --session <id> is used, NOT -r (Pi's interactive picker)."""
+        with patch(
+            "symphony_linear.pi.agent_runner.run",
+            return_value=(0, _fixture_text(), "", None),
+        ) as runner:
+            run_resume(
+                workspace_path="/workspace",
+                tmp_path="/workspace/tmp",
+                session_id="pi-session-abc",
+                message="continue",
+                timeout_seconds=60,
+                idle_timeout_seconds=30,
+                on_subprocess=lambda process: None,
+            )
+
+        cmd = runner.call_args.kwargs["cmd"]
+        assert "-r" not in cmd
+        assert "--session" in cmd
+        idx = cmd.index("--session")
+        assert cmd[idx + 1] == "pi-session-abc"
+
+    def test_resume_command_full_structure(self) -> None:
+        with patch(
+            "symphony_linear.pi.agent_runner.run",
+            return_value=(0, _fixture_text(), "", None),
+        ) as runner:
+            message, context_tokens = run_resume(
+                workspace_path="/workspace",
+                tmp_path="/workspace/tmp",
+                session_id="pi-session-abc",
+                message="\ncontinue",
+                timeout_seconds=60,
+                idle_timeout_seconds=30,
+                on_subprocess=lambda process: None,
+                files=["/workspace/attachments/followup.txt"],
+                model="anthropic/claude-opus-5",
+            )
+
+        assert (message, context_tokens) == ("hello", 3015)
+        assert runner.call_args.kwargs["cmd"] == [
+            "pi",
+            "-p",
+            "--mode",
+            "json",
+            "--session",
+            "pi-session-abc",
+            "--model",
+            "anthropic/claude-opus-5",
+            "@/workspace/attachments/followup.txt",
+            "\n\ncontinue",
+        ]
+
+    def test_newline_prefix_unconditional_even_when_already_present(self) -> None:
+        """Prompt already starting with newline still gets an extra prefix."""
+        with patch(
+            "symphony_linear.pi.agent_runner.run",
+            return_value=(0, _fixture_text(), "", None),
+        ) as runner:
+            run_initial(
+                workspace_path="/workspace",
+                tmp_path="/workspace/tmp",
+                prompt="\nalready prefixed",
+                timeout_seconds=60,
+                idle_timeout_seconds=30,
+                on_subprocess=lambda process: None,
+            )
+
+        cmd = runner.call_args.kwargs["cmd"]
+        assert cmd[-1] == "\n\nalready prefixed"
+
+    def test_newline_prefix_on_at_sign_prompt(self) -> None:
+        """Prompt starting with '@' must be prefixed to avoid attachment parse."""
+        with patch(
+            "symphony_linear.pi.agent_runner.run",
+            return_value=(0, _fixture_text(), "", None),
+        ) as runner:
+            run_initial(
+                workspace_path="/workspace",
+                tmp_path="/workspace/tmp",
+                prompt="@developer do this",
+                timeout_seconds=60,
+                idle_timeout_seconds=30,
+                on_subprocess=lambda process: None,
+            )
+
+        cmd = runner.call_args.kwargs["cmd"]
+        assert cmd[-1] == "\n@developer do this"
+
+    def test_resume_newline_prefix_unconditional(self) -> None:
+        with patch(
+            "symphony_linear.pi.agent_runner.run",
+            return_value=(0, _fixture_text(), "", None),
+        ) as runner:
+            run_resume(
+                workspace_path="/workspace",
+                tmp_path="/workspace/tmp",
+                session_id="pi-session-abc",
+                message="@reply to this",
+                timeout_seconds=60,
+                idle_timeout_seconds=30,
+                on_subprocess=lambda process: None,
+            )
+
+        cmd = runner.call_args.kwargs["cmd"]
+        assert cmd[-1] == "\n@reply to this"
+
+    @pytest.mark.parametrize("session_id", ["", None])
+    def test_resume_rejects_empty_session_id(self, session_id: str | None) -> None:
+        with patch("symphony_linear.pi.agent_runner.run") as runner:
+            with pytest.raises(PiError, match="non-empty session_id"):
+                run_resume(
+                    workspace_path="/workspace",
+                    tmp_path="/workspace/tmp",
+                    session_id=session_id,
+                    message="continue",
+                    timeout_seconds=60,
+                    idle_timeout_seconds=30,
+                    on_subprocess=lambda process: None,
+                )
+
+        runner.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Environment
+# ---------------------------------------------------------------------------
+
+
+class TestEnvironment:
+    """Pi adapter env: HOME always, PI_CODING_AGENT_DIR only when set."""
+
+    def test_env_always_contains_home(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("PI_CODING_AGENT_DIR", raising=False)
+
+        with patch(
+            "symphony_linear.pi.agent_runner.run",
+            return_value=(0, _fixture_text(), "", None),
+        ) as runner:
+            _run_initial()
+
+        env = runner.call_args.kwargs["env"]
+        assert "HOME" in env
+        assert env["HOME"] == str(Path.home())
+
+    def test_env_contains_pi_coding_agent_dir_when_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("PI_CODING_AGENT_DIR", "/custom/pi/agent")
+
+        with patch(
+            "symphony_linear.pi.agent_runner.run",
+            return_value=(0, _fixture_text(), "", None),
+        ) as runner:
+            _run_initial()
+
+        env = runner.call_args.kwargs["env"]
+        assert env.get("PI_CODING_AGENT_DIR") == "/custom/pi/agent"
+
+    def test_env_omits_pi_coding_agent_dir_when_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("PI_CODING_AGENT_DIR", raising=False)
+
+        with patch(
+            "symphony_linear.pi.agent_runner.run",
+            return_value=(0, _fixture_text(), "", None),
+        ) as runner:
+            _run_initial()
+
+        env = runner.call_args.kwargs["env"]
+        assert "PI_CODING_AGENT_DIR" not in env
+
+
+# ---------------------------------------------------------------------------
+# Agent dir extra_rw_paths handling
+# ---------------------------------------------------------------------------
+
+
+class TestAgentDirRwPaths:
+    """PI_CODING_AGENT_DIR is appended to extra_rw_paths when set and is a dir."""
+
+    def test_agent_dir_appended_when_env_set_and_dir_exists(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        agent_dir = tmp_path / "pi_agent"
+        agent_dir.mkdir()
+        monkeypatch.setenv("PI_CODING_AGENT_DIR", str(agent_dir))
+
+        with patch(
+            "symphony_linear.pi.agent_runner.run",
+            return_value=(0, _fixture_text(), "", None),
+        ) as runner:
+            _run_initial()
+
+        extra_rw = runner.call_args.kwargs["extra_rw_paths"]
+        assert str(agent_dir) in extra_rw
+
+    def test_agent_dir_not_appended_when_env_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("PI_CODING_AGENT_DIR", raising=False)
+
+        with patch(
+            "symphony_linear.pi.agent_runner.run",
+            return_value=(0, _fixture_text(), "", None),
+        ) as runner:
+            _run_initial(extra_rw_paths=[])
+
+        extra_rw = runner.call_args.kwargs["extra_rw_paths"]
+        assert extra_rw == []
+
+    def test_agent_dir_not_appended_when_dir_missing(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        missing_dir = tmp_path / "nonexistent_pi_agent"
+        monkeypatch.setenv("PI_CODING_AGENT_DIR", str(missing_dir))
+
+        with patch(
+            "symphony_linear.pi.agent_runner.run",
+            return_value=(0, _fixture_text(), "", None),
+        ) as runner:
+            _run_initial()
+
+        extra_rw = runner.call_args.kwargs["extra_rw_paths"]
+        assert str(missing_dir) not in extra_rw
+
+    def test_warning_emitted_when_dir_missing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        missing_dir = tmp_path / "nonexistent_pi_agent"
+        monkeypatch.setenv("PI_CODING_AGENT_DIR", str(missing_dir))
+
+        with caplog.at_level(logging.WARNING, logger="symphony_linear.pi"):
+            with patch(
+                "symphony_linear.pi.agent_runner.run",
+                return_value=(0, _fixture_text(), "", None),
+            ):
+                _run_initial()
+
+        warning_messages = [
+            r.message for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert len(warning_messages) == 1
+        assert str(missing_dir) in warning_messages[0]
+        assert "EROFS" in warning_messages[0]
+
+    def test_no_warning_when_env_unset(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        monkeypatch.delenv("PI_CODING_AGENT_DIR", raising=False)
+
+        with caplog.at_level(logging.WARNING, logger="symphony_linear.pi"):
+            with patch(
+                "symphony_linear.pi.agent_runner.run",
+                return_value=(0, _fixture_text(), "", None),
+            ):
+                _run_initial()
+
+        warning_messages = [
+            r.message for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert warning_messages == []
+
+    def test_no_warning_when_dir_exists(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        agent_dir = tmp_path / "pi_agent"
+        agent_dir.mkdir()
+        monkeypatch.setenv("PI_CODING_AGENT_DIR", str(agent_dir))
+
+        with caplog.at_level(logging.WARNING, logger="symphony_linear.pi"):
+            with patch(
+                "symphony_linear.pi.agent_runner.run",
+                return_value=(0, _fixture_text(), "", None),
+            ):
+                _run_initial()
+
+        warning_messages = [
+            r.message for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert warning_messages == []
+
+    def test_agent_dir_deduplicated_when_already_in_extra_rw_paths(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        agent_dir = tmp_path / "pi_agent"
+        agent_dir.mkdir()
+        monkeypatch.setenv("PI_CODING_AGENT_DIR", str(agent_dir))
+
+        with patch(
+            "symphony_linear.pi.agent_runner.run",
+            return_value=(0, _fixture_text(), "", None),
+        ) as runner:
+            # Pass the same path in extra_rw_paths already
+            _run_initial(extra_rw_paths=[str(agent_dir)])
+
+        extra_rw = runner.call_args.kwargs["extra_rw_paths"]
+        # Should appear exactly once
+        assert extra_rw.count(str(agent_dir)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Exit validation
+# ---------------------------------------------------------------------------
+
+
+class TestExitValidation:
+    """The adapter preserves cancellation and validation priority."""
+
+    def test_signal_exit_wins_over_missing_session(self) -> None:
+        with patch(
+            "symphony_linear.pi.agent_runner.run",
+            return_value=(-9, "not NDJSON", "", None),
+        ):
+            with pytest.raises(PiCancelled, match="killed by signal 9"):
+                _run_initial()
+
+    def test_nonzero_exit_wins_over_missing_session_and_keeps_stderr_tail(
+        self,
+    ) -> None:
+        stderr = "bootstrap-start\n" + ("padding\n" * 1000) + "actual failure\n"
+        with patch(
+            "symphony_linear.pi.agent_runner.run",
+            return_value=(1, "not NDJSON", stderr, None),
+        ):
+            with pytest.raises(PiError) as excinfo:
+                _run_initial()
+
+        assert "actual failure" in str(excinfo.value)
+        assert "bootstrap-start" not in str(excinfo.value)
+
+    def test_zero_exit_without_session_is_an_error(self) -> None:
+        with patch(
+            "symphony_linear.pi.agent_runner.run",
+            return_value=(0, '{"type":"turn_start"}', "", None),
+        ):
+            with pytest.raises(PiError, match="No session ID"):
+                _run_initial()
+
+    def test_exception_names_alias_agent_runner_exceptions(self) -> None:
+        assert PiError is agent_runner.AgentError
+        assert PiTimeout is agent_runner.AgentTimeout
+        assert PiCancelled is agent_runner.AgentCancelled
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_initial(
+    extra_rw_paths: list[str] | None = None,
+) -> tuple[str, str, int | None]:
+    """Run a representative initial Pi turn through the mocked runner."""
+    return run_initial(
+        workspace_path="/workspace",
+        tmp_path="/workspace/tmp",
+        prompt="do it",
+        timeout_seconds=60,
+        idle_timeout_seconds=30,
+        on_subprocess=lambda process: None,
+        extra_rw_paths=extra_rw_paths,
+    )

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -487,6 +487,32 @@ class TestRunInSandbox:
         omp_dir = str(fake_home / ".omp")
         assert ("--bind-try", omp_dir, omp_dir) in zip(args, args[1:], args[2:])
 
+    def test_pi_dir_bind_try_emitted(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Emit an optional read-write bind for Pi state (~/.pi)."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        fake_home = tmp_path / "fake_home"
+        fake_home.mkdir()
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        with patch(
+            "symphony_linear.sandbox.shutil.which", return_value="/usr/bin/bwrap"
+        ):
+            with patch("symphony_linear.sandbox.subprocess.Popen") as popen_mock:
+                run_in_sandbox(
+                    cmd=["echo", "hello"],
+                    workspace_path=str(workspace),
+                    tmp_path=str(_make_ticket_tmp(tmp_path)),
+                    hide_paths=[],
+                    env={"HOME": str(fake_home)},
+                )
+
+        args = popen_mock.call_args[0][0]
+        pi_dir = str(fake_home / ".pi")
+        assert ("--bind-try", pi_dir, pi_dir) in zip(args, args[1:], args[2:])
+
     def test_extra_rw_paths_writable(self, tmp_path: Path) -> None:
         """Verify that extra_rw_paths are writable inside the sandbox."""
         _require_bwrap()


### PR DESCRIPTION
Wanted to propose pi-based distros like tlh, but I figured it made sense to have a minimal pi implementation first.

Have tested it on my symphony and it works fine.

## Summary

- add Pi as a third selectable coding agent alongside OpenCode and OMP
- add a Pi adapter using the existing `agent_runner.py` execution and NDJSON parsing pattern
- persist Pi authentication and session state through the sandbox, including `PI_CODING_AGENT_DIR` overrides
- dispatch initial and resumed turns through Pi while preserving per-session agent tagging

Pi differs from OMP in a few load-bearing CLI details: non-interactive resume uses `--session <id>` rather than OMP's `-r <id>`; Pi has no `--cwd` or `--auto-approve` flags; and prompts are newline-prefixed so leading `@` text is not interpreted as an attachment.

This PR intentionally contains only vanilla Pi support. Compatible distro/wrapper binary support is kept out of this change.

## Testing

- `915 passed, 21 skipped` (`.venv/bin/pytest -q`; skips require `bwrap`, unavailable on macOS)
- `uvx ruff@0.15.12 check symphony_linear tests`
- `uvx ruff@0.15.12 format --check symphony_linear tests`
- config validation smoke tests for present and missing Pi binaries
